### PR TITLE
[DATN-98] Move API Gateway rewrites logic to Code or Application.yml

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
     import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
-  
 
 ---
 spring:
@@ -13,3 +12,23 @@ spring:
     activate:
       on-profile: docker
     import: configserver:${CONFIG_SERVER_URL:http://config-server:8888/}
+
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: presentation
+              uri: lb://presentations
+              predicates:
+                - Path=/presentations/**
+            - id: auth
+              uri: lb://auth
+              predicates:
+                - Path=/auth/**
+            - id: ai-service
+              uri: lb://ai-service
+              predicates:
+                - Path=/api/ai/**
+              filters:
+                - RewritePath=/api/ai(?<segment>.*), /$\{segment}


### PR DESCRIPTION
Moved the rewrites logic from `config repo` to this repository and within `api-gateway service`.

## Current configuration

#### Config repo: `api-gateway.yml`
> In `dev` and also in `docker`
```yml
server:
  port: 8080
spring:
  application:
    name: api-gateway
  cloud:
    gateway:
      server:
        webflux:
          global-cors:
            add-to-simple-url-handler-mapping: true
            cors-configurations:
              '[/**]':
                allowed-origin-patterns: ${ALLOWED_ORIGINS:http://localhost:*}
                allowed-methods: [GET, POST, PUT, DELETE, OPTIONS]
                allowed-headers: "*"
                allow-credentials: true

eureka:
  client:
    service-url:
      defaultZone: ${EUREKA_URI:http://discovery-service:8761/eureka/}
    register-with-eureka: true
    fetch-registry: true
  instance:
    prefer-ip-address: true
```
#### `api-gateway`'s application.yml
```yml
spring:
  application:
    name: api-gateway
  config:
    import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
  profiles:
    active: ${SPRING_PROFILES_ACTIVE:dev}

---
spring:
  config:
    activate:
      on-profile: docker
    import: configserver:${CONFIG_SERVER_URL:http://config-server:8888/}

  cloud:
    gateway:
      server:
        webflux:
          routes:
            - id: presentation
              uri: lb://presentations
              predicates:
                - Path=/presentations/**
            - id: auth
              uri: lb://auth
              predicates:
                - Path=/auth/**
            - id: ai-service
              uri: lb://ai-service
              predicates:
                - Path=/api/ai/**
              filters:
                - RewritePath=/api/ai(?<segment>.*), /$\{segment}
```